### PR TITLE
Added missing wisdomCheck param to ashiotameru and stamina shoubu

### DIFF
--- a/RaceSolverBuilder.ts
+++ b/RaceSolverBuilder.ts
@@ -560,6 +560,7 @@ export class RaceSolverBuilder {
 					skillId: 'asitame',
 					perspective: Perspective.Self,
 					rarity: SkillRarity.White,
+					wisdomCheck: false,
 					regions: spurtStart,
 					samplePolicy: ImmediatePolicy,
 					extraCondition: (_) => true,
@@ -594,6 +595,7 @@ export class RaceSolverBuilder {
 					skillId: 'staminasyoubu',
 					perspective: Perspective.Self,
 					rarity: SkillRarity.White,
+					wisdomCheck: false,
 					regions: spurtStart,
 					samplePolicy: ImmediatePolicy,
 					// TODO do current speed skills count toward reaching max speed or not?


### PR DESCRIPTION
Include `wisdomCheck` in the object (to stay type correct with the SkillData interface).

Not sure how this didn't get caught during build/transpile? I'm not familiar with how the uma-tools repo consumes these files, but shouldn't this have been a build break?

The objects used in `skillData.push()` resulted in ts error 2345 since those objects weren't of the expected interface shape. 